### PR TITLE
Added stats for Projects and Milestones

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,3 +6,4 @@ Contributors
 ------------
 Marco Federighi <m.federighi@nephila.it>
 Carlo Ascani <c.ascani@nephila.it>
+Erik Westrup <erik.westrup@gmail.com>

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -159,6 +159,13 @@ class Milestone(InstanceResource):
         'user_stories': UserStories,
     }
 
+    def stats(self):
+        response = self.requester.get(
+            '/{endpoint}/{id}/stats',
+            endpoint=self.endpoint, id=self.id
+        )
+        return response.json()
+
 
 class Milestones(ListResource):
 
@@ -368,6 +375,13 @@ class Project(InstanceResource):
         'points': Points,
         'us_statuses': UserStoryStatuses
     }
+
+    def stats(self):
+        response = self.requester.get(
+            '/{endpoint}/{id}/stats',
+            endpoint=self.endpoint, id=self.id
+        )
+        return response.json()
 
     def star(self):
         self.requester.post(

--- a/tests/test_milestones.py
+++ b/tests/test_milestones.py
@@ -35,3 +35,15 @@ class TestMilestones(unittest.TestCase):
         mock_requestmaker_post.assert_called_with('milestones',
             payload={'project': 1, 'estimated_finish': '2015-02-16',
             'estimated_start': '2015-01-16', 'name': 'Sprint Jan'})
+
+    @patch('taiga.requestmaker.RequestMaker.get')
+    def test_stats(self, mock_requestmaker_get):
+        mock_requestmaker_get.return_value = MockResponse(200,
+            create_mock_json('tests/resources/milestone_details_success.json'))
+        api = TaigaAPI(token='f4k3')
+        milestone = api.milestones.get(1)
+        milestone.stats()
+        mock_requestmaker_get.assert_called_with(
+            '/{endpoint}/{id}/stats',
+            endpoint='milestones', id=milestone.id
+        )

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -33,6 +33,16 @@ class TestProjects(unittest.TestCase):
         self.assertEqual(len(projects[0].users), 1)
         self.assertTrue(isinstance(projects[0].users[0], User))
 
+    @patch('taiga.requestmaker.RequestMaker.get')
+    def test_stats(self, mock_requestmaker_get):
+        rm = RequestMaker('/api/v1', 'fakehost', 'faketoken')
+        project = Project(rm, id=1)
+        project.stats()
+        mock_requestmaker_get.assert_called_with(
+            '/{endpoint}/{id}/stats',
+            endpoint='projects', id=1
+        )
+
     @patch('taiga.requestmaker.RequestMaker.post')
     def test_star(self, mock_requestmaker_post):
         rm = RequestMaker('/api/v1', 'fakehost', 'faketoken')


### PR DESCRIPTION
First of all: wonderful project, I like working with python-taiga!

I want to fetch out some project stats but the stats API calls for Projects and Milestones were missing. I added these two calls and associated test cases with them.

API doc:
http://taigaio.github.io/taiga-doc/dist/api.html#projects-stats
http://taigaio.github.io/taiga-doc/dist/api.html#milestones-stats