### PR TITLE
Minor improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 sudo: false
 
 python:
+  - 3.5
   - 3.4
   - 3.3
   - 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - 2.6
 
 install:
-  - pip install -r requirements-test.txt
+  - travis_retry pip install -r requirements-test.txt
 
 before_script:
   - flake8 taiga

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -1005,6 +1005,16 @@ class Project(InstanceResource):
         )
         return response.json()
 
+    def issues_stats(self):
+        """
+        Get stats for issues of the project
+        """
+        response = self.requester.get(
+            '/{endpoint}/{id}/issues_stats',
+            endpoint=self.endpoint, id=self.id
+        )
+        return response.json()
+
     def like(self):
         """
         Like the project

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -87,6 +87,16 @@ class TestProjects(unittest.TestCase):
             endpoint='projects', id=1
         )
 
+    @patch('taiga.requestmaker.RequestMaker.get')
+    def test_issues_stats(self, mock_requestmaker_get):
+        rm = RequestMaker('/api/v1', 'fakehost', 'faketoken')
+        project = Project(rm, id=1)
+        project.issues_stats()
+        mock_requestmaker_get.assert_called_with(
+            '/{endpoint}/{id}/issues_stats',
+            endpoint='projects', id=1
+        )
+
     @patch('taiga.requestmaker.RequestMaker.post')
     def test_like(self, mock_requestmaker_post):
         rm = RequestMaker('/api/v1', 'fakehost', 'faketoken')


### PR DESCRIPTION
- Add project/<project_id>/issues_stats Api call
- Run tests in Python 3.5
- Prevent failures for timeouts during installing requirements in travis-ci (http://docs.travis-ci.com/user/build-timeouts/)