### PR TITLE
Remove is_archived from User Story object

### DIFF
--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -271,7 +271,6 @@ class UserStory(CustomAttributeResource, CommentableResource):
     :param version: version of the :class:`UserStory`
     :param client_requirement: client requirement of the :class:`UserStory`
     :param description: description of the :class:`UserStory`
-    :param is_archived: is archived of the :class:`UserStory`
     :param is_blocked: is blocked of the :class:`UserStory`
     :param kanban_order: kanban order of the :class:`UserStory`
     :param milestone: milestone of the :class:`UserStory`
@@ -290,10 +289,9 @@ class UserStory(CustomAttributeResource, CommentableResource):
 
     allowed_params = [
         'assigned_to', 'backlog_order', 'blocked_note', 'version',
-        'client_requirement', 'description', 'is_archived', 'is_blocked',
-        'is_closed', 'kanban_order', 'milestone', 'points', 'project',
-        'sprint_order', 'status', 'subject', 'tags', 'team_requirement',
-        'watchers'
+        'client_requirement', 'description', 'is_blocked', 'is_closed',
+        'kanban_order', 'milestone', 'points', 'project', 'sprint_order',
+        'status', 'subject', 'tags', 'team_requirement', 'watchers'
     ]
 
     def add_task(self, subject, status, **attrs):

--- a/tests/resources/milestone_details_success.json
+++ b/tests/resources/milestone_details_success.json
@@ -28,7 +28,6 @@
             "owner":21921,
             "status":null,
             "is_closed":false,
-            "is_archived":false,
             "backlog_order":10000,
             "sprint_order":10000,
             "kanban_order":10000,

--- a/tests/resources/milestones_list_success.json
+++ b/tests/resources/milestones_list_success.json
@@ -29,7 +29,6 @@
                 "owner":21921,
                 "status":null,
                 "is_closed":false,
-                "is_archived":false,
                 "backlog_order":10000,
                 "sprint_order":10000,
                 "kanban_order":10000,

--- a/tests/resources/search_success.json
+++ b/tests/resources/search_success.json
@@ -64,7 +64,6 @@
             "owner":21921,
             "status":null,
             "is_closed":false,
-            "is_archived":false,
             "backlog_order":10000,
             "sprint_order":10000,
             "kanban_order":10000,

--- a/tests/resources/userstories_list_success.json
+++ b/tests/resources/userstories_list_success.json
@@ -27,7 +27,6 @@
         "owner":21921,
         "status":116330,
         "is_closed":false,
-        "is_archived":false,
         "backlog_order":10000,
         "sprint_order":10000,
         "kanban_order":10000,

--- a/tests/resources/userstory_details_success.json
+++ b/tests/resources/userstory_details_success.json
@@ -26,7 +26,6 @@
     "owner":21921,
     "status":116330,
     "is_closed":false,
-    "is_archived":false,
     "backlog_order":10000,
     "sprint_order":10000,
     "kanban_order":10000,


### PR DESCRIPTION
I've had some problem using the is_archived boolean on User Stories
since the server did never return such a thing for User Stories. After
some email conversations with the Taiga developers it turns out that the
API documentation has been wrong for a while. The only thing that has an
'is_archived' attribute is the User Story Status detail object.

They have now updated the API docs with this. Therefore I remove the
is_archived attribute on US in this patch.

NOTE I've not been able to run the nosetests this time like I've been
able to do before. There were some problems installing the mock module
from PIP. Can some one else verify that this works? :)