### PR TITLE
Only remove .coverage if it exists to avoid error message

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-rm .coverage
+test ! -e .coverage || rm .coverage
 flake8 taiga
 nosetests --with-coverage --cover-package=taiga


### PR DESCRIPTION
If there were not .coverage file when runtests.sh is invoked an error
message was printed out. This patch changes the test script so it tests
for the existence for the file before trying to remove it.