### PR TITLE
Change README.rst to README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     description="Taiga python API",
-    long_description=read('README.rst'),
+    long_description=read('README.md'),
     license="MIT",
     author="Nephila",
     author_email="info@nephila.it",


### PR DESCRIPTION
`python setup.py egg_info` can't find README.rst
fixes issue #45