### PR TITLE
Unsecure login and auth_type

### DIFF
--- a/taiga/requestmaker.py
+++ b/taiga/requestmaker.py
@@ -4,6 +4,7 @@ import time
 from . import exceptions, utils
 from distutils.version import LooseVersion
 from requests.exceptions import RequestException
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 
 def _disable_pagination():
@@ -56,12 +57,15 @@ class RequestMakerException(Exception):
 
 class RequestMaker(object):
 
-    def __init__(self, api_path, host, token, token_type='Bearer'):
+    def __init__(self, api_path, host, token, token_type='Bearer', tls_verify=True):
         self.api_path = api_path
         self.host = host
         self.token = token
         self.token_type = token_type
+        self.tls_verify = tls_verify
         self._cache = RequestCache()
+        if not self.tls_verify:
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
     @property
     def cache(self):
@@ -107,7 +111,8 @@ class RequestMaker(object):
                 result = requests.get(
                     full_url,
                     headers=self.headers(),
-                    params=query
+                    params=query,
+                    verify=self.tls_verify
                 )
             if cache:
                 self._cache.put(full_url, result)
@@ -144,7 +149,8 @@ class RequestMaker(object):
                 headers=headers,
                 data=data,
                 params=query,
-                files=files
+                files=files,
+                verify=self.tls_verify
             )
         except RequestException:
             raise exceptions.TaigaRestException(
@@ -168,7 +174,8 @@ class RequestMaker(object):
             result = requests.delete(
                 full_url,
                 headers=self.headers(),
-                params=query
+                params=query,
+                verify=self.tls_verify
             )
         except RequestException:
             raise exceptions.TaigaRestException(
@@ -193,7 +200,8 @@ class RequestMaker(object):
                 full_url,
                 headers=self.headers(),
                 data=json.dumps(payload),
-                params=query
+                params=query,
+                verify=self.tls_verify
             )
         except RequestException:
             raise exceptions.TaigaRestException(
@@ -218,7 +226,8 @@ class RequestMaker(object):
                 full_url,
                 headers=self.headers(),
                 data=json.dumps(payload),
-                params=query
+                params=query,
+                verify=self.tls_verify
             )
         except RequestException:
             raise exceptions.TaigaRestException(

--- a/taiga/requestmaker.py
+++ b/taiga/requestmaker.py
@@ -57,7 +57,11 @@ class RequestMakerException(Exception):
 
 class RequestMaker(object):
 
-    def __init__(self, api_path, host, token, token_type='Bearer', tls_verify=True):
+    def __init__(self,
+                 api_path, host,
+                 token,
+                 token_type='Bearer',
+                 tls_verify=True):
         self.api_path = api_path
         self.host = host
         self.token = token

--- a/tests/test_requestmaker.py
+++ b/tests/test_requestmaker.py
@@ -29,6 +29,7 @@ class TestRequestMaker(unittest.TestCase):
         rm.post('nowhere', files={'sample' : file_desc})
         requests_post.assert_called_once_with(
             'http://host/v1/nowhere', files={'sample' : file_desc},
+            verify=True,
             data=None, params={},
             headers={
                 'Authorization': 'Bearer f4k3',


### PR DESCRIPTION
Allow the connection to a Taiga host using a self-signed certificate (also ignore the InsecureWarning triggered by urllib3).

Taiga offers other types of authentication (LDAP, github, ...), so the key 'type' in the payload for the auth request can't be hard coded to 'normal'. 