### PR TITLE
Update setup.py to include URL to GitHub repository.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     license="MIT",
     author="Nephila",
     author_email="info@nephila.it",
-    url="",
+    url="https://github.com/nephila/python-taiga",
     keywords="taiga kanban wrapper api",
     install_requires=[
         "requests",


### PR DESCRIPTION
Before, there was no link from [PyPi](https://pypi.python.org/pypi/python-taiga) page to the GitHub repository with the source. This is fixed by setting `url` in setup.py