### PR TITLE
Avoid installing tests as a separate module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ classifiers = [
 setup(
     name="python-taiga",
     version=__version__,
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     description="Taiga python API",
     long_description=read('README.rst'),


### PR DESCRIPTION
The tests directory is currently being built as a separate module by setup.py. When python-taiga is installed, the tests are installed as a separate module (in /usr/local/lib/python2.7/dist-packages/tests) and can be imported using `import tests` (though the module is quite useless).

This change excludes the tests from the identified packages. Thus, it will no longer be installed.