### PR TITLE
Move dateutil import

### DIFF
--- a/taiga/models/base.py
+++ b/taiga/models/base.py
@@ -1,4 +1,3 @@
-import dateutil.parser
 import re
 import six
 
@@ -137,6 +136,8 @@ class InstanceResource(Resource):
     repr_attribute = 'name'
 
     def __init__(self, requester, **params):
+        import dateutil.parser
+
         self.requester = requester
         for key, value in six.iteritems(params):
             if key in ['created_date', 'modified_date']:


### PR DESCRIPTION
This is needed as tox 3.0 changed the import order and dateutil is imported before the environment is ready