### PR TITLE
Disable pagination for user story history

### DIFF
--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -1677,7 +1677,8 @@ class HistoryEntity(object):
         """
         response = self.requester.get(
             '/{endpoint}/{entity}/{id}',
-            endpoint=self.endpoint, entity=self.entity, id=resource_id
+            endpoint=self.endpoint, entity=self.entity, id=resource_id,
+            paginate=False
         )
         return response.json()
 


### PR DESCRIPTION
There is currently no way to request additional pages. Pagination thus causes involuntarily truncation of the history.

See #75.