### PR TITLE
Fix for issue #114

### DIFF
--- a/changes/114.bugfix
+++ b/changes/114.bugfix
@@ -1,0 +1,1 @@
+Add refresh token support to tests/resources/auth_users_success.json

--- a/taiga/client.py
+++ b/taiga/client.py
@@ -139,6 +139,7 @@ class TaigaAPI:
         if response.status_code != 200:
             raise exceptions.TaigaRestException(full_url, response.status_code, response.text, "POST")
         self.token = response.json()["auth_token"]
+        self.token_refresh = response.json()["refresh"]
         self.raw_request = RequestMaker("/api/v1", self.host, self.token, "Bearer", self.tls_verify)
         self._init_resources()
 

--- a/tests/resources/auth_user_success.json
+++ b/tests/resources/auth_user_success.json
@@ -12,5 +12,6 @@
    "big_photo":"http://taiga/media/user/b/1/3/1/r2d2android2.png.300x300_q85_crop.jpg",
    "full_name":"Andrea Stagi",
    "auth_token":"f4k3",
+   "refresh":"j5l4",
    "default_timezone":""
 }


### PR DESCRIPTION
# Description

Describe:

Updates tests/resources/auth_user_success.json file to add support for the `refresh` token
Adds support in `client.py` for the returned `refresh` token.

## References

Fixes bug #114 

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added*

* tests `tox -e py3.9` and `inv lint` run locally