### PR TITLE
Fix pagination

### DIFF
--- a/changes/116.bugfix
+++ b/changes/116.bugfix
@@ -1,0 +1,1 @@
+Fix pagination

--- a/taiga/models/base.py
+++ b/taiga/models/base.py
@@ -58,6 +58,8 @@ class ListResource(Resource):
             except (ValueError, TypeError):
                 page_size = 100
             queryparams["page_size"] = page_size
+        if page and pagination:
+            queryparams["page"] = page
         result = self.requester.get(self.instance.endpoint, query=queryparams, paginate=pagination)
         objects = SearchableList()
         objects.extend(self.parse_list(result.json()))

--- a/tests/test_model_base.py
+++ b/tests/test_model_base.py
@@ -245,13 +245,13 @@ class TestModelBase(unittest.TestCase):
         mock_requestmaker_get.return_value = MockResponse(200, data)
         f_list = fakes.list(page_size=5, page=1)
         self.assertEqual(len(f_list), 5)
-        mock_requestmaker_get.assert_called_with("fakes", query={"page_size": 5}, paginate=True)
+        mock_requestmaker_get.assert_called_with("fakes", query={"page_size": 5, "page": 1}, paginate=True)
 
         data = json.dumps(js_list[5:])
         mock_requestmaker_get.return_value = MockResponse(200, data)
         f_list = fakes.list(page_size=5, page=2)
         self.assertEqual(len(f_list), 4)
-        mock_requestmaker_get.assert_called_with("fakes", query={"page_size": 5}, paginate=True)
+        mock_requestmaker_get.assert_called_with("fakes", query={"page_size": 5, "page": 2}, paginate=True)
 
     def test_to_dict_method(self):
         rm = RequestMaker("/api/v1", "fakehost", "faketoken")

--- a/tests/test_user_stories.py
+++ b/tests/test_user_stories.py
@@ -22,6 +22,33 @@ class TestUserStories(unittest.TestCase):
         mock_requestmaker_get.assert_called_with("userstories/attachments", query={"object_id": 1}, paginate=True)
 
     @patch("taiga.requestmaker.RequestMaker.get")
+    def test_list_userstories_page_2(self, mock_requestmaker_get):
+        mock_requestmaker_get.return_value = MockResponse(
+            200, create_mock_json("tests/resources/userstories_list_success.json")
+        )
+        api = TaigaAPI(token="f4k3")
+        api.user_stories.list(page=1, page_size=2)
+        mock_requestmaker_get.assert_called_with("userstories", query={"page_size": 2, "page": 1}, paginate=True)
+
+    @patch("taiga.requestmaker.RequestMaker.get")
+    def test_list_userstories_page_1(self, mock_requestmaker_get):
+        mock_requestmaker_get.return_value = MockResponse(
+            200, create_mock_json("tests/resources/userstories_list_success.json")
+        )
+        api = TaigaAPI(token="f4k3")
+        api.user_stories.list(page_size=2)
+        mock_requestmaker_get.assert_called_with("userstories", query={"page_size": 2}, paginate=True)
+
+    @patch("taiga.requestmaker.RequestMaker.get")
+    def test_list_userstories_no_pagination(self, mock_requestmaker_get):
+        mock_requestmaker_get.return_value = MockResponse(
+            200, create_mock_json("tests/resources/userstories_list_success.json")
+        )
+        api = TaigaAPI(token="f4k3")
+        api.user_stories.list(pagination=False, page=2, page_size=3)
+        mock_requestmaker_get.assert_called_with("userstories", query={}, paginate=False)
+
+    @patch("taiga.requestmaker.RequestMaker.get")
     def test_single_userstory_parsing(self, mock_requestmaker_get):
         mock_requestmaker_get.return_value = MockResponse(
             200, create_mock_json("tests/resources/userstory_details_success.json")


### PR DESCRIPTION
# Description

Page parameter was not passed to querystring, thus pagination failed

Ensure page parameter is actually passed to query parameters


## References

Fix #116 

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
