### PR TITLE
Add moveTo parameter to delete methods when needed by Taiga API

### DIFF
--- a/changes/130.bugfix
+++ b/changes/130.bugfix
@@ -1,0 +1,1 @@
+Add moveTo parameter in delete methods when needed by Taiga API

--- a/taiga/models/base.py
+++ b/taiga/models/base.py
@@ -92,8 +92,8 @@ class ListResource(Resource):
         response = self.requester.get("/{endpoint}/{id}", endpoint=self.instance.endpoint, id=resource_id)
         return self.instance.parse(self.requester, response.json())
 
-    def delete(self, resource_id):
-        self.requester.delete("/{endpoint}/{id}", endpoint=self.instance.endpoint, id=resource_id)
+    def delete(self, resource_id, query=None):
+        self.requester.delete("/{endpoint}/{id}", endpoint=self.instance.endpoint, id=resource_id, query=query)
         return self
 
     def _new_resource(self, **attrs):
@@ -170,11 +170,11 @@ class InstanceResource(Resource):
             self.__dict__["version"] = obj_json["version"]
         return self
 
-    def delete(self):
+    def delete(self, query=None):
         """
         Delete the current :class:`InstanceResource`
         """
-        self.requester.delete("/{endpoint}/{id}", endpoint=self.endpoint, id=self.id)
+        self.requester.delete("/{endpoint}/{id}", endpoint=self.endpoint, id=self.id, query=query)
         return self
 
     def to_dict(self):

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -6,6 +6,24 @@ from .. import exceptions
 from .base import InstanceResource, ListResource
 
 
+class MoveOnDestroyMixinList:
+    """
+    Mixin that define a delete method with moveTo parameter
+    """
+
+    def delete(self, resource_id, move_to_id):
+        return super().delete(resource_id=resource_id, query={"moveTo": move_to_id})
+
+
+class MoveOnDestroyMixinObject:
+    """
+    Mixin that define a delete method with moveTo parameter
+    """
+
+    def delete(self, move_to_id):
+        return super().delete(query={"moveTo": move_to_id})
+
+
 class CommentableResource(InstanceResource):
     """
     CommentableResource base class
@@ -155,7 +173,7 @@ class Memberships(ListResource):
         return self._new_resource(payload=attrs)
 
 
-class Priority(InstanceResource):
+class Priority(MoveOnDestroyMixinObject, InstanceResource):
     """
     Priority model
 
@@ -172,7 +190,7 @@ class Priority(InstanceResource):
     repr_attribute = "name"
 
 
-class Priorities(ListResource):
+class Priorities(MoveOnDestroyMixinList, ListResource):
     """
     Priorities factory class
     """
@@ -345,7 +363,7 @@ class Epics(ListResource):
         return self._new_resource(payload=attrs)
 
 
-class EpicStatus(InstanceResource):
+class EpicStatus(MoveOnDestroyMixinObject, InstanceResource):
     """
     Taiga Epic Status model
 
@@ -364,7 +382,7 @@ class EpicStatus(InstanceResource):
     allowed_params = ["color", "is_closed", "name", "order", "project", "slug`"]
 
 
-class EpicStatuses(ListResource):
+class EpicStatuses(MoveOnDestroyMixinList, ListResource):
     instance = EpicStatus
 
     def create(self, project, name, **attrs):
@@ -495,7 +513,7 @@ class UserStories(ListResource):
         return self.instance.parse(self.requester, response.json())
 
 
-class UserStoryStatus(InstanceResource):
+class UserStoryStatus(MoveOnDestroyMixinObject, InstanceResource):
     """
     Taiga User Story Status model
 
@@ -514,7 +532,7 @@ class UserStoryStatus(InstanceResource):
     allowed_params = ["color", "is_closed", "name", "order", "project", "wip_limit"]
 
 
-class UserStoryStatuses(ListResource):
+class UserStoryStatuses(MoveOnDestroyMixinList, ListResource):
     instance = UserStoryStatus
 
     def create(self, project, name, **attrs):
@@ -529,7 +547,7 @@ class UserStoryStatuses(ListResource):
         return self._new_resource(payload=attrs)
 
 
-class Point(InstanceResource):
+class Point(MoveOnDestroyMixinObject, InstanceResource):
     """
     Taiga Point model
 
@@ -547,7 +565,7 @@ class Point(InstanceResource):
     allowed_params = ["color", "value", "name", "order", "project"]
 
 
-class Points(ListResource):
+class Points(MoveOnDestroyMixinList, ListResource):
     """
     Points factory
     """
@@ -653,7 +671,7 @@ class Milestones(ListResource):
         return self.instance.parse(self.requester, response.json())
 
 
-class TaskStatus(InstanceResource):
+class TaskStatus(MoveOnDestroyMixinObject, InstanceResource):
     """
     Task Status model
 
@@ -669,7 +687,7 @@ class TaskStatus(InstanceResource):
     allowed_params = ["name", "color", "order", "project", "is_closed"]
 
 
-class TaskStatuses(ListResource):
+class TaskStatuses(MoveOnDestroyMixinList, ListResource):
     instance = TaskStatus
 
     def create(self, project, name, **attrs):
@@ -792,7 +810,7 @@ class Tasks(ListResource):
         return self.instance.parse(self.requester, response.json())
 
 
-class IssueType(InstanceResource):
+class IssueType(MoveOnDestroyMixinObject, InstanceResource):
     """
     IssueType model
 
@@ -807,7 +825,7 @@ class IssueType(InstanceResource):
     allowed_params = ["name", "color", "order", "project"]
 
 
-class IssueTypes(ListResource):
+class IssueTypes(MoveOnDestroyMixinList, ListResource):
     """
     IssueTypes factory
     """
@@ -819,7 +837,7 @@ class IssueTypes(ListResource):
         return self._new_resource(payload=attrs)
 
 
-class IssueStatus(InstanceResource):
+class IssueStatus(MoveOnDestroyMixinObject, InstanceResource):
     """
     Issue Status model
 
@@ -835,7 +853,7 @@ class IssueStatus(InstanceResource):
     allowed_params = ["name", "color", "order", "project", "is_closed"]
 
 
-class IssueStatuses(ListResource):
+class IssueStatuses(MoveOnDestroyMixinList, ListResource):
     """
     IssueStatuses factory
     """
@@ -1044,7 +1062,7 @@ class EpicAttributes(CustomAttributes):
     instance = EpicAttribute
 
 
-class Severity(InstanceResource):
+class Severity(MoveOnDestroyMixinObject, InstanceResource):
     """
     Severity model
 
@@ -1059,7 +1077,7 @@ class Severity(InstanceResource):
     allowed_params = ["name", "color", "order", "project"]
 
 
-class Severities(ListResource):
+class Severities(MoveOnDestroyMixinList, ListResource):
     """
     Severities factory
     """

--- a/tests/test_issue_statuses.py
+++ b/tests/test_issue_statuses.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models import IssueStatus, IssueStatuses
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestIssueStatuses(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestIssueStatuses(unittest.TestCase):
         mock_new_resource.return_value = IssueStatus(rm)
         IssueStatuses(rm).create(1, "IST 1")
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "IST 1"})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_issue_statuses(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        IssueStatuses(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/issue-statuses/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_issue_status(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        IssueStatus(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/issue-statuses/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )

--- a/tests/test_issue_types.py
+++ b/tests/test_issue_types.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models.models import IssueType, IssueTypes
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestIssueTypes(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestIssueTypes(unittest.TestCase):
         mock_new_resource.return_value = IssueType(rm)
         IssueTypes(rm).create(1, "IT 1")
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "IT 1"})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_issue_types(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        IssueTypes(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/issue-types/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_issue_type(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        IssueType(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/issue-types/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )

--- a/tests/test_model_base.py
+++ b/tests/test_model_base.py
@@ -114,7 +114,14 @@ class TestModelBase(unittest.TestCase):
         rm = RequestMaker("/api/v1", "fakehost", "faketoken")
         fake = Fake(rm, id=1, param1="one", param2="two")
         fake.delete()
-        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1)
+        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1, query=None)
+
+    @patch("taiga.requestmaker.RequestMaker.delete")
+    def test_call_model_base_delete_with_query(self, mock_requestmaker_delete):
+        rm = RequestMaker("/api/v1", "fakehost", "faketoken")
+        fake = Fake(rm, id=1, param1="one", param2="two")
+        fake.delete(2)
+        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1, query=2)
 
     @patch("taiga.requestmaker.RequestMaker.get")
     def test_call_model_base_get_element(self, mock_requestmaker_get):
@@ -128,14 +135,28 @@ class TestModelBase(unittest.TestCase):
         rm = RequestMaker("/api/v1", "fakehost", "faketoken")
         fake = Fake(rm, id=1, param1="one", param2="two")
         fake.delete()
-        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1)
+        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1, query=None)
+
+    @patch("taiga.requestmaker.RequestMaker.delete")
+    def test_call_model_base_delete_element_with_query(self, mock_requestmaker_delete):
+        rm = RequestMaker("/api/v1", "fakehost", "faketoken")
+        fake = Fake(rm, id=1, param1="one", param2="two")
+        fake.delete(1)
+        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1, query=1)
 
     @patch("taiga.requestmaker.RequestMaker.delete")
     def test_call_model_base_delete_element_from_list(self, mock_requestmaker_delete):
         rm = RequestMaker("/api/v1", "fakehost", "faketoken")
         fakes = Fakes(rm)
         fakes.delete(1)
-        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1)
+        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1, query=None)
+
+    @patch("taiga.requestmaker.RequestMaker.delete")
+    def test_call_model_base_delete_element_from_list_with_query(self, mock_requestmaker_delete):
+        rm = RequestMaker("/api/v1", "fakehost", "faketoken")
+        fakes = Fakes(rm)
+        fakes.delete(1, 2)
+        mock_requestmaker_delete.assert_called_once_with("/{endpoint}/{id}", endpoint="fakes", id=1, query=2)
 
     @patch("taiga.requestmaker.RequestMaker.get")
     def test_call_model_base_list_elements(self, mock_requestmaker_get):

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models import Point, Points
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestPoints(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestPoints(unittest.TestCase):
         mock_new_resource.return_value = Point(rm)
         Points(rm).create(1, "Point 1", 4)
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "Point 1", "value": 4})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_points(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        Points(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/points/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_point(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        Point(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/points/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )

--- a/tests/test_priorities.py
+++ b/tests/test_priorities.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models import Priorities, Priority
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestPriorities(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestPriorities(unittest.TestCase):
         mock_new_resource.return_value = Priority(rm)
         Priorities(rm).create(1, "Priority 1")
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "Priority 1"})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_priorities(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        Priorities(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/priorities/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_priority(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        Priority(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/priorities/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )

--- a/tests/test_severities.py
+++ b/tests/test_severities.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models import Severities, Severity
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestSeverities(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestSeverities(unittest.TestCase):
         mock_new_resource.return_value = Severity(rm)
         Severities(rm).create(1, "SV 1")
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "SV 1"})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_severities(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        Severities(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/severities/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_severity(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        Severity(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/severities/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )

--- a/tests/test_task_statuses.py
+++ b/tests/test_task_statuses.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models import TaskStatus, TaskStatuses
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestTaskStatuses(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestTaskStatuses(unittest.TestCase):
         mock_new_resource.return_value = TaskStatus(rm)
         TaskStatuses(rm).create(1, "TS 1")
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "TS 1"})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_task_statuses(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        TaskStatuses(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/task-statuses/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_task_status(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        TaskStatus(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/task-statuses/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )

--- a/tests/test_userstory_statuses.py
+++ b/tests/test_userstory_statuses.py
@@ -4,6 +4,8 @@ from unittest.mock import patch
 from taiga.models import UserStoryStatus, UserStoryStatuses
 from taiga.requestmaker import RequestMaker
 
+from .tools import MockResponse
+
 
 class TestPriorities(unittest.TestCase):
     @patch("taiga.models.base.ListResource._new_resource")
@@ -12,3 +14,27 @@ class TestPriorities(unittest.TestCase):
         mock_new_resource.return_value = UserStoryStatus(rm)
         UserStoryStatuses(rm).create(1, "USS 1")
         mock_new_resource.assert_called_with(payload={"project": 1, "name": "USS 1"})
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_user_story_statuses(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        UserStoryStatuses(rm).delete(1, 2)
+        requests_delete.assert_called_with(
+            "host/api/v1/userstory-statuses/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )
+
+    @patch("taiga.requestmaker.requests.delete")
+    def test_delete_user_story_status(self, requests_delete):
+        rm = RequestMaker(api_path="/api/v1", host="host", token="f4k3")
+        requests_delete.return_value = MockResponse(204, "")
+        UserStoryStatus(rm, id=1).delete(2)
+        requests_delete.assert_called_with(
+            "host/api/v1/userstory-statuses/1",
+            headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
+            params={"moveTo": 2},
+            verify=True,
+        )


### PR DESCRIPTION
# Description

Add moveTo parameter to delete methods when needed by Taiga API

## References

Fix #130

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
