### PR TITLE
fix: upade WikiPage

### DIFF
--- a/changes/149.bugfix
+++ b/changes/149.bugfix
@@ -1,0 +1,1 @@
+add the version parameter to the alloed parameter so the requester can acess it.

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -1765,7 +1765,7 @@ class WikiPage(InstanceResource):
 
     repr_attribute = "slug"
 
-    allowed_params = ["project", "slug", "content", "watchers"]
+    allowed_params = ["project", "slug", "content", "watchers", "version"]
 
     def attach(self, attached_file, **attrs):
         """


### PR DESCRIPTION
# Description

fix [issue 149](https://github.com/nephila/python-taiga/issues/149) as discussed. Adds the version parameter to the allowed_params, so the requester can access it.

## References

 GitHub issue 149 fixed

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [ ] Tests added
