### PR TITLE
feature/161 - Add duplicate() method to Project (#161)

### DIFF
--- a/changes/161.feature
+++ b/changes/161.feature
@@ -1,0 +1,1 @@
+Add a duplicate() method to Project.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -101,6 +101,18 @@ Create a project
     new_project = api.projects.create('TEST PROJECT', 'TESTING API')
 
 ******************************************************
+Duplicate an existing project
+******************************************************
+
+If you have a project, you can duplicate it (duplicates most of the settings,
+but not the user stories or tasks)
+
+.. code:: python
+
+    old_project = api.projects.get_by_slug('nephila')
+    new_project = old_project.duplicate('TEST PROJECT', 'TESTING API')
+
+******************************************************
 Create a new user story
 ******************************************************
 

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -1701,6 +1701,20 @@ class Project(InstanceResource):
         response = self.requester.get("/{}/{}/tags_colors".format(self.endpoint, self.id))
         return response.json()
 
+    def duplicate(self, name, description, is_private=False, users=[], **attrs):
+        """
+        Duplicate a :class:`Project`
+
+        :param name: name of new :class:`Project`
+        :param description: description of new :class:`Project`
+        :param is_private: determines if the project is private or not
+        :param users: users of the new :class:`Project`
+        :param attrs: optional attributes for the new :class:`Project`
+        """
+        attrs.update({"name": name, "description": description, "is_private": is_private, "users": users})
+        response = self.requester.post("/{endpoint}/{id}/duplicate", payload=attrs, endpoint=self.endpoint, id=self.id)
+        return self.parse(self.requester, response.json())
+
 
 class Projects(ListResource):
     """

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -177,6 +177,18 @@ class TestProjects(unittest.TestCase):
             endpoint="importer",
         )
 
+    @patch("taiga.requestmaker.RequestMaker.post")
+    def test_duplicate_project(self, mock_requestmaker_post):
+        rm = RequestMaker("/api/v1", "fakehost", "faketoken")
+        project = Project(rm, id=1)
+        project.duplicate("PR 1 1", "PR 1 desc 1")
+        mock_requestmaker_post.assert_called_with(
+            "/{endpoint}/{id}/duplicate",
+            payload={"name": "PR 1 1", "description": "PR 1 desc 1", "is_private": False, "users": []},
+            endpoint="projects",
+            id=project.id,
+        )
+
     @patch("taiga.models.IssueStatuses.create")
     def test_add_issue_status(self, mock_new_issue_status):
         rm = RequestMaker("/api/v1", "fakehost", "faketoken")


### PR DESCRIPTION
# Description

This PR adds a `duplicate()` method to the `Project` model, which will duplicate the project on Taiga when called.  This causes Taiga to make a new project using the newly specified name/description/is_private/users, but copying the original project's settings, including color names, priorities, etc.  It does not duplicate any user stories or tasks.

## References

Fix #161 

# Checklist

* [X] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [X] Code lint checked via `inv lint`
* [X] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [X] Usage documentation added in case of new features
* [X] Tests added