### PR TITLE
Allow reading/writing default_swimlane in Project (#166)

### DIFF
--- a/changes/166.feature
+++ b/changes/166.feature
@@ -1,0 +1,1 @@
+Adds the ability to read/write the default_swimlane attribute in Project.

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -1192,6 +1192,7 @@ class Project(InstanceResource):
     allowed_params = [
         "name",
         "description",
+        "default_swimlane",
         "creation_template",
         "is_backlog_activated",
         "is_issues_activated",

--- a/tests/resources/project_details_success.json
+++ b/tests/resources/project_details_success.json
@@ -809,6 +809,7 @@
     "default_task_status": 1,
     "default_priority": 2,
     "default_severity": 3,
+    "default_swimlane": 1,
     "default_issue_status": 429,
     "default_issue_type": 1,
     "name": "Project Example 0",


### PR DESCRIPTION
# Description

Adds support for reading/writing `default_swimlane` in `Project`.  Like any other property, you can read it:

```python
print(project.default_swimlane)
```

or update it:

```python
project.default_swimlane = 5
project.update()
```

## References

Fixes #166 

# Checklist

* [X] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [X] Code lint checked via `inv lint`
* [X] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added

Note I did not add any tests specifically, but did add the `default_swimlane` property to one of the resource JSONs.  As far as I can see, there are not tests to see if various parameters are returned when a GET happens.  Similarly, there were not docs on reading individual attributes so I did not update those.