### PR TITLE
Fix parsing error when entry from dict returns None

### DIFF
--- a/taiga/models/base.py
+++ b/taiga/models/base.py
@@ -104,14 +104,16 @@ class ListResource(Resource):
     def parse(cls, requester, entries):
         """Parse a JSON array into a list of model instances."""
         result_entries = SearchableList()
-        for entry in entries:
+        entry_list = entries if entries else []
+        for entry in entry_list:
             result_entries.append(cls.instance.parse(requester, entry))
         return result_entries
 
     def parse_list(self, entries):
         """Parse a JSON array into a list of model instances."""
         result_entries = SearchableList()
-        for entry in entries:
+        entry_list = entries if entries else []
+        for entry in entry_list:
             result_entries.append(self.instance.parse(self.requester, entry))
         return result_entries
 


### PR DESCRIPTION
# Description

Describe:

* Content of the pull request

Fixes error when the entries is `None`.

* Feature added / Problem fixed

```
TypeError: 'NoneType' object is not iterable
```

# Checklist

* [X] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [X] Code lint checked via `inv lint`
* [ ] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
