### PR TITLE
Add swimlane to user story allowed_params

### DIFF
--- a/changes/185.bugfix
+++ b/changes/185.bugfix
@@ -1,0 +1,1 @@
+Add missing swimlane to user story allowed_params

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -453,6 +453,7 @@ class UserStory(CustomAttributeResource, CommentableResource):
         "due_date",
         "generated_from_issue",
         "generated_from_task",
+        "swimlane",
     ]
 
     def add_task(self, subject, status, **attrs):


### PR DESCRIPTION
# Description

Add swimlane to user story allowed_params

## References

This should fix #185 

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [x] Tests added
