### PR TITLE
Adds proxies parameter to taiga client and requestmaker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Robin Gustafsson <git@rgson.se>
 Daniel Federschmidt <daniel@federschmidt.xyz>
 Robert Dyer <rdyer@unl.edu>
 Patrick Szczepański <p.szczepanski996@gmail.com>
+Hassen Ben Tanfous <hassen.ben-tanfous@docaposte.fr>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,15 @@ History
 
 .. towncrier release notes start
 
+1.4.0 (2025-08-07)
+==================
+
+Features
+--------
+
+- Add proxies parameter to taiga client (#55)
+
+
 1.3.2 (2025-01-22)
 ==================
 

--- a/changes/55.feature
+++ b/changes/55.feature
@@ -1,0 +1,1 @@
+Add proxies parameter to taiga client

--- a/changes/55.feature
+++ b/changes/55.feature
@@ -1,1 +1,0 @@
-Add proxies parameter to taiga client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ commit = true
 message = "Release {new_version}"
 commit_args = "--no-verify"
 tag = false
-current_version = "1.3.3.dev1"
+current_version = "1.4.0"
 parse = """(?x)
     (?P<major>[0-9]+)
     \\.(?P<minor>[0-9]+)

--- a/taiga/__init__.py
+++ b/taiga/__init__.py
@@ -5,7 +5,7 @@
 """
 Taiga Python API library
 """
-__version__ = "1.3.3.dev1"
+__version__ = "1.4.0"
 __author__ = "Nephila"
 __license__ = "MIT"
 __all__ = ["TaigaAPI"]

--- a/taiga/requestmaker.py
+++ b/taiga/requestmaker.py
@@ -49,13 +49,16 @@ class RequestMakerException(Exception):  # noqa: N818
 
 
 class RequestMaker:
-    def __init__(self, api_path, host, token, token_type="Bearer", tls_verify=True, enable_pagination=True):
+    def __init__(
+        self, api_path, host, token, token_type="Bearer", tls_verify=True, enable_pagination=True, proxies=None
+    ):
         self.api_path = api_path
         self.host = host
         self.token = token
         self.token_type = token_type
         self.tls_verify = tls_verify
         self.enable_pagination = enable_pagination
+        self.proxies = proxies
         self._cache = RequestCache()
         if not self.tls_verify:
             requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
@@ -99,7 +102,11 @@ class RequestMaker:
 
             if not result:
                 result = requests.get(
-                    full_url, headers=self.headers(paginate), params=query or {}, verify=self.tls_verify
+                    full_url,
+                    headers=self.headers(paginate),
+                    params=query or {},
+                    verify=self.tls_verify,
+                    proxies=self.proxies,
                 )
             if cache:
                 self._cache.put(full_url, result)
@@ -124,7 +131,13 @@ class RequestMaker:
         try:
             full_url = self.urljoin(self.host, self.api_path, uri.format(**parameters))
             result = requests.post(
-                full_url, headers=headers, data=data, params=query or {}, files=files, verify=self.tls_verify
+                full_url,
+                headers=headers,
+                data=data,
+                params=query or {},
+                files=files,
+                verify=self.tls_verify,
+                proxies=self.proxies,
             )
         except RequestException:
             raise exceptions.TaigaRestException(full_url, 400, "Network error!", "POST")
@@ -136,7 +149,9 @@ class RequestMaker:
     def delete(self, uri, query=None, **parameters):
         try:
             full_url = self.urljoin(self.host, self.api_path, uri.format(**parameters))
-            result = requests.delete(full_url, headers=self.headers(), params=query or {}, verify=self.tls_verify)
+            result = requests.delete(
+                full_url, headers=self.headers(), params=query or {}, verify=self.tls_verify, proxies=self.proxies
+            )
         except RequestException:
             raise exceptions.TaigaRestException(full_url, 400, "Network error!", "DELETE")
         if not self.is_bad_response(result):
@@ -148,7 +163,12 @@ class RequestMaker:
         try:
             full_url = self.urljoin(self.host, self.api_path, uri.format(**parameters))
             result = requests.put(
-                full_url, headers=self.headers(), data=json.dumps(payload), params=query or {}, verify=self.tls_verify
+                full_url,
+                headers=self.headers(),
+                data=json.dumps(payload),
+                params=query or {},
+                verify=self.tls_verify,
+                proxies=self.proxies,
             )
         except RequestException:
             raise exceptions.TaigaRestException(full_url, 400, "Network error!", "PUT")
@@ -161,7 +181,12 @@ class RequestMaker:
         try:
             full_url = self.urljoin(self.host, self.api_path, uri.format(**parameters))
             result = requests.patch(
-                full_url, headers=self.headers(), data=json.dumps(payload), params=query or {}, verify=self.tls_verify
+                full_url,
+                headers=self.headers(),
+                data=json.dumps(payload),
+                params=query or {},
+                verify=self.tls_verify,
+                proxies=self.proxies,
             )
         except RequestException:
             raise exceptions.TaigaRestException(full_url, 400, "Network error!", "PATCH")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -67,6 +67,7 @@ class TestAuth(unittest.TestCase):
             data='{"refresh": "testToken"}',
             headers={"Content-type": "application/json"},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.client.requests.post")

--- a/tests/test_issue_statuses.py
+++ b/tests/test_issue_statuses.py
@@ -25,6 +25,7 @@ class TestIssueStatuses(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestIssueStatuses(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_issue_types.py
+++ b/tests/test_issue_types.py
@@ -25,6 +25,7 @@ class TestIssueTypes(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestIssueTypes(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_model_base.py
+++ b/tests/test_model_base.py
@@ -232,6 +232,7 @@ class TestModelBase(unittest.TestCase):
                 "Content-type": "application/json",
                 "Authorization": "Bearer faketoken",
             },
+            proxies=None,
         )
         self.assertEqual(len(f_list), 9)
 
@@ -253,6 +254,7 @@ class TestModelBase(unittest.TestCase):
                 "Content-type": "application/json",
                 "Authorization": "Bearer faketoken",
             },
+            proxies=None,
         )
         self.assertEqual(len(f_list), 9)
 

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -25,6 +25,7 @@ class TestPoints(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestPoints(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_priorities.py
+++ b/tests/test_priorities.py
@@ -25,6 +25,7 @@ class TestPriorities(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestPriorities(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_requestmaker.py
+++ b/tests/test_requestmaker.py
@@ -37,6 +37,7 @@ class TestRequestMaker(unittest.TestCase):
             data=None,
             params={},
             headers={"Authorization": "Bearer f4k3", "x-disable-pagination": "True"},
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.put")

--- a/tests/test_severities.py
+++ b/tests/test_severities.py
@@ -25,6 +25,7 @@ class TestSeverities(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestSeverities(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_swimlanes.py
+++ b/tests/test_swimlanes.py
@@ -25,6 +25,7 @@ class TestSwimLanes(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestSwimLanes(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_task_statuses.py
+++ b/tests/test_task_statuses.py
@@ -25,6 +25,7 @@ class TestTaskStatuses(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestTaskStatuses(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )

--- a/tests/test_userstory_statuses.py
+++ b/tests/test_userstory_statuses.py
@@ -25,6 +25,7 @@ class TestPriorities(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )
 
     @patch("taiga.requestmaker.requests.delete")
@@ -37,4 +38,5 @@ class TestPriorities(unittest.TestCase):
             headers={"Content-type": "application/json", "Authorization": "Bearer f4k3", "x-lazy-pagination": "True"},
             params={"moveTo": 2},
             verify=True,
+            proxies=None,
         )


### PR DESCRIPTION
# Description

Describe:

Simple change that adds a proxies parameter to taiga client and requestmaker
Updated the affected existings tests, still thinking about the tests to add.
Not sure if this needs a usage documentation.

## References

#55 

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [] Usage documentation added in case of new features
* [] Tests added
