### PR TITLE
Fix auth_app for modern Taiga versions (#227)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ Daniel Federschmidt <daniel@federschmidt.xyz>
 Robert Dyer <rdyer@unl.edu>
 Patrick Szczepański <p.szczepanski996@gmail.com>
 Hassen Ben Tanfous <hassen.ben-tanfous@docaposte.fr>
+Melissa Eckardt <melissa.eckardt@gdata-adan.de>

--- a/changes/227.bugfix
+++ b/changes/227.bugfix
@@ -1,0 +1,1 @@
+Fix auth_app method to work with Taiga versions >= 3.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
     requests>2.11
     six>=1.9
     python-dateutil>=2.4
-    pyjwkest>=1.0
 packages = taiga
 python_requires = >=3.7
 setup_requires =

--- a/taiga/client.py
+++ b/taiga/client.py
@@ -161,13 +161,19 @@ class TaigaAPI:
         )
         self._init_resources()
 
-    def auth_app(self, app_id, app_secret, auth_code, state=""):
+    def auth_app(self, app_id, auth_code, state):
         """
-        Authenticate an app
+        Retrieve an application token.
+        This only works once per token; in order to reset it, the auth code needs
+        to be set again in the Taiga admin UI.
+
+        In order to use the token, initialize TaigaAPI with token_type="Application"
+        and token="token from this function".
 
         :param app_id: the app id
-        :param app_secret: the app secret
-        :param auth_code: the app auth code
+        :param auth_code: app auth code as specified in Taiga
+        :param state: state as specified in Taiga (any string; must not be empty)
+        :return: token string
         """
         headers = {"Content-type": "application/json"}
         payload = {"application": app_id, "auth_code": auth_code, "state": state}
@@ -180,31 +186,12 @@ class TaigaAPI:
             raise exceptions.TaigaRestException(full_url, 400, "NETWORK ERROR", "POST")
         if response.status_code != 200:
             raise exceptions.TaigaRestException(full_url, response.status_code, response.text, "POST")
-        cyphered_token = response.json().get("cyphered_token", "")
-        if cyphered_token:
-            from jwkest.jwe import JWE
-            from jwkest.jwk import SYMKey
+        token = response.json().get("token", None)
 
-            sym_key = SYMKey(key=app_secret, alg="A128KW")
-            data, success = JWE().decrypt(cyphered_token, keys=[sym_key]), True
-            if isinstance(data, tuple):
-                data, success = data
-            try:
-                self.token = json.loads(data.decode("utf-8")).get("token", None)
-            except ValueError:  # pragma: no cover
-                self.token = None
-            if not success:
-                self.token = None
-        else:
-            self.token = None
-
-        if self.token is None:
+        if token is None:
             raise exceptions.TaigaRestException(full_url, 400, "INVALID TOKEN", "POST")
 
-        self.raw_request = RequestMaker(
-            "/api/v1", self.host, self.token, "Application", self.tls_verify, proxies=self.proxies
-        )
-        self._init_resources()
+        return token
 
     def refresh_token(self, token_refresh=""):
         """

--- a/tests/resources/auth_app_success.json
+++ b/tests/resources/auth_app_success.json
@@ -1,3 +1,3 @@
 {
-    "cyphered_token": "eyJhbGciOiJBMTI4S1ciLCJlbmMiOiJBMjU2R0NNIn0.9C2qwG_R0B22Qws6umB1gbqpLiH2rfVJbwgtJlxWBqPtYhhG-Ioc1g.RBBVW4k2k8t44aEo.VFsRiipfRMKXVGQxdGcnM6k.8uaF6FoQiPxX6wdFU2AyYA"
+    "token": "eyJhcHBfdG9rZW5faWQiOjN9:1utpZt:fXS-ifJ6TGWQEy7IkkxemDPGM5jXTOYYn7heGf8MFWU"
 }

--- a/tests/test_auth_app.py
+++ b/tests/test_auth_app.py
@@ -14,8 +14,8 @@ class TestAuthApp(unittest.TestCase):
     def test_auth_success(self, requests):
         requests.post.return_value = MockResponse(200, create_mock_json("tests/resources/auth_app_success.json"))
         api = TaigaAPI(host="host")
-        api.auth_app("valid-app-id", "valid-app-secret", "valid-auth-code", "valid-state")
-        self.assertEqual(api.token, "f4k3")
+        token = api.auth_app("valid-app-id", "valid-auth-code", "valid-state")
+        self.assertEqual(token, "eyJhcHBfdG9rZW5faWQiOjN9:1utpZt:fXS-ifJ6TGWQEy7IkkxemDPGM5jXTOYYn7heGf8MFWU")
 
     @patch("taiga.client.requests")
     def test_auth_not_success(self, requests):
@@ -25,7 +25,6 @@ class TestAuthApp(unittest.TestCase):
             taiga.exceptions.TaigaRestException,
             api.auth_app,
             "valid-app-id",
-            "valid-app-secret",
             "valid-auth-code",
             "valid-state",
         )
@@ -38,7 +37,6 @@ class TestAuthApp(unittest.TestCase):
             taiga.exceptions.TaigaRestException,
             api.auth_app,
             "valid-app-id",
-            "valid-app-pass",
             "valid-auth-code",
             "valid-state",
         )


### PR DESCRIPTION
# Description

* Fix `auth_app()` to (only) work with Taiga 3.1.0+ (released in 2016).
* The method returns the token now instead of setting it up in the API client. This is because it's not really meant to be used like `auth()` - rather, it only works once per token because the Taiga backend invalidates the `auth_code` during the request. From what I can tell, applications are supposed to store and re-use the token. It doesn't have an expiration, unlike Bearer tokens.
* Dependency pyjwkest is no longer required.

## References

Fixes #227
Due to removal of dependency, also fixes #189

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [ ] Usage documentation added in case of new features
* [ ] Tests added
