### PR TITLE
chore: support Python 3.11-3.14, drop 3.7-3.10, update CI actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -58,7 +58,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -71,6 +71,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/debian_package.yml
+++ b/.github/workflows/debian_package.yml
@@ -7,7 +7,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Install dependencies
       run: |
         sudo apt-get install -yq --no-install-suggests --no-install-recommends devscripts fakeroot equivs dh-python python3-all python3-dateutil python3-requests python3-six

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,26 +8,26 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        python-version: ["3.11.x"]
+        python-version: ["3.14.x"]
         toxenv: [ruff, isort, black, pypi-description, docs, towncrier]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.toxenv }}
     - name: Cache tox
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: .tox
         key: ${{ runner.os }}-lint-${{ matrix.toxenv }}-${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,20 +8,20 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.toxenv }}
     - name: Cache tox
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: .tox
         key: ${{ runner.os }}-tox-release-${{ hashFiles('setup.cfg') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,22 +8,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.10", "3.9"]
+        python-version: ["3.14", "3.13", "3.12", "3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.toxenv }}
         restore-keys: |
           ${{ runner.os }}-pip-${{ matrix.toxenv }}
     - name: Cache tox
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: .tox
         key: ${{ runner.os }}-tox-${{ format('{{py{0}}}', matrix.python-version) }}-${{ hashFiles('setup.cfg') }}
@@ -47,7 +47,7 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel: true
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,16 +31,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py3-plus
-  - repo: https://github.com/adamchainz/django-upgrade
-    rev: "1.31.1"
-    hooks:
-      - id: django-upgrade
-        args: [--target-version, "3.2"]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
+          - --py311-plus
   - repo: local
     hooks:
       - id: towncrier

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.10"
+    python: "3.13"
 
 sphinx:
   configuration: docs/conf.py

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -114,7 +114,7 @@ Testing tips
 ------------
 You can test your project using any specific version of python.
 
-For example ``tox -epy37`` runs the tests on python 3.7.
+For example ``tox -epy311`` runs the tests on python 3.11.
 
 Pull Request Guidelines
 =======================

--- a/changes/265.chore
+++ b/changes/265.chore
@@ -1,0 +1,1 @@
+Add support for Python 3.12, 3.13 and 3.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 119
-target-version = ["py310"]
+target-version = ["py311"]
 
 [tool.towncrier]
 package = "taiga"
@@ -40,11 +40,13 @@ multi_line_output = 3
 use_parentheses = true
 
 [tool.ruff]
-ignore = []
 line-length = 119
-target-version = "py310"
+target-version = "py311"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint]
+ignore = []
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
 [tool.bumpversion]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,21 +17,19 @@ classifiers =
     Development Status :: 5 - Production/Stable
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 include_package_data = True
 install_requires =
     requests>2.11
-    six>=1.9
     python-dateutil>=2.4
     pyjwkest>=1.0
 packages = taiga
-python_requires = >=3.7
+python_requires = >=3.11
 setup_requires =
 	setuptools
 zip_safe = False

--- a/taiga/exceptions.py
+++ b/taiga/exceptions.py
@@ -17,5 +17,5 @@ class TaigaRestException(TaigaException):  # noqa: N818
         except ValueError:
             pass
         if not message:
-            message = "Status: {} on URI: {}".format(status_code, uri)
+            message = f"Status: {status_code} on URI: {uri}"
         super().__init__(message)

--- a/taiga/models/base.py
+++ b/taiga/models/base.py
@@ -203,9 +203,9 @@ class InstanceResource(Resource):
 
     def __repr__(self):
         try:
-            return "{}({})".format(self.__class__.__name__, self.id)
+            return f"{self.__class__.__name__}({self.id})"
         except AttributeError:
-            return "{}({})".format(self.__class__.__name__, id(self))
+            return f"{self.__class__.__name__}({id(self)})"
 
     def __str__(self):
         return self._rp()
@@ -213,6 +213,6 @@ class InstanceResource(Resource):
     def _rp(self):
         attr = getattr(self, self.repr_attribute, None)
         if attr:
-            return "{}".format(attr)
+            return f"{attr}"
         else:
             return repr(self)

--- a/taiga/models/models.py
+++ b/taiga/models/models.py
@@ -52,7 +52,7 @@ class CustomAttributeResource(InstanceResource):
         :param version: version of the attribute (default = 1)
         """
         attributes = self._get_attributes(cache=True)
-        formatted_id = "{}".format(id)
+        formatted_id = f"{id}"
         attributes["attributes_values"][formatted_id] = value
         response = self.requester.patch(
             "/{endpoint}/custom-attributes-values/{id}",
@@ -1746,14 +1746,14 @@ class Project(InstanceResource):
         attrs = {"tag": tag}
         if color:
             attrs["color"] = color
-        response = self.requester.post("/{}/{}/create_tag".format(self.endpoint, self.id), payload=attrs)
+        response = self.requester.post(f"/{self.endpoint}/{self.id}/create_tag", payload=attrs)
         return response
 
     def list_tags(self):
         """
         Get the list of tags for the project.
         """
-        response = self.requester.get("/{}/{}/tags_colors".format(self.endpoint, self.id))
+        response = self.requester.get(f"/{self.endpoint}/{self.id}/tags_colors")
         return response.json()
 
     def duplicate(self, name, description, is_private=False, users=[], **attrs):

--- a/taiga/requestmaker.py
+++ b/taiga/requestmaker.py
@@ -73,7 +73,7 @@ class RequestMaker:
     def headers(self, paginate=True):
         headers = {
             "Content-type": "application/json",
-            "Authorization": "{} {}".format(self.token_type, self.token),
+            "Authorization": f"{self.token_type} {self.token}",
         }
         if self.enable_pagination and paginate:
             headers["x-lazy-pagination"] = "True"
@@ -120,7 +120,7 @@ class RequestMaker:
     def post(self, uri, payload=None, query=None, files=None, **parameters):
         if files:
             headers = {
-                "Authorization": "{} {}".format(self.token_type, self.token),
+                "Authorization": f"{self.token_type} {self.token}",
                 "x-disable-pagination": "True",
             }
             data = payload

--- a/tasks.py
+++ b/tasks.py
@@ -20,7 +20,7 @@ def clean(c):
     patterns.append("docs/_build")
     patterns.append("**/*.pyc")
     for pattern in patterns:
-        c.run("rm -rf {}".format(pattern))
+        c.run(f"rm -rf {pattern}")
 
 
 @task

--- a/tests/test_model_base.py
+++ b/tests/test_model_base.py
@@ -339,4 +339,4 @@ class TestModelBase(unittest.TestCase):
         self.assertEqual(fake._rp(), str(fake))
         fake.repr_attribute = "notexisting"
         rep = fake._rp()
-        self.assertEqual(rep, "{}({})".format(fake.__class__.__name__, fake.id))
+        self.assertEqual(rep, f"{fake.__class__.__name__}({fake.id})")

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
     ruff
     pypi-description
     towncrier
-    py{311,310,39}
+    py{314,313,312,311}
 
 [testenv]
 commands = {env:COMMAND:python} -m pytest {posargs}


### PR DESCRIPTION
- Drop support for Python 3.7, 3.8, 3.9 and 3.10; add classifiers and tox/CI matrices for 3.12, 3.13 and 3.14 (keeping 3.11)
- Bump python_requires to >=3.11
- Bump black/ruff target-version to py311
- Move ruff's `ignore`/`mccabe` settings under `[tool.ruff.lint]` to drop a deprecation warning
- Bump pre-commit's pyupgrade to --py311-plus, drop the duplicate pyupgrade hook and the django-upgrade hook (not a Django project)
- Bump readthedocs build Python to 3.13
- Remove unused `six` dependency from install_requires
- Update all GitHub Actions to their latest major versions (checkout@v7, setup-python@v7, cache@v6, codecov-action@v7, codeql-action@v4)
- Add towncrier changelog fragments

# Description

Describe:

* Content of the pull request
* Feature added / Problem fixed

## References

Provide any github issue fixed (as in ``Fix #XYZ``)

# Checklist

* [x] I have read the [contribution guide](https://python-taiga.readthedocs.io/en/latest/contributing.html)
* [x] Code lint checked via `inv lint`
* [x] ``changes`` file included (see [docs](https://python-taiga.readthedocs.io/en/latest/contributing.html#pull-request-guidelines))
* [x] Usage documentation added in case of new features
* [x] Tests added
